### PR TITLE
Standardize GitHub Actions workflows

### DIFF
--- a/.github/workflows/EssentialsPlugins-builds-caller.yml
+++ b/.github/workflows/EssentialsPlugins-builds-caller.yml
@@ -1,5 +1,3 @@
-name: Build Essentials Plugin
-
 on:
   push:
     branches:
@@ -10,7 +8,7 @@ jobs:
     uses: PepperDash/workflow-templates/.github/workflows/essentialsplugins-getversion.yml@main
     secrets: inherit
 
-  build-3Series-self-hosted:  
+  build-3Series:
     uses: PepperDash/workflow-templates/.github/workflows/essentialsplugins-3Series-builds.yml@main
     secrets: inherit
     needs: getVersion
@@ -20,15 +18,3 @@ jobs:
       version: ${{ needs.getVersion.outputs.version }}
       tag: ${{ needs.getVersion.outputs.tag }}
       channel: ${{ needs.getVersion.outputs.channel }}
-  
-  # build-4Series:
-  #   uses: PepperDash/workflow-templates/.github/workflows/essentialsplugins-4Series-builds.yml@main
-  #   secrets: inherit
-  #   needs: getVersion
-  #   if: needs.getVersion.outputs.newVersion == 'true'
-  #   with:
-  #     newVersion: ${{ needs.getVersion.outputs.newVersion }}
-  #     version: ${{ needs.getVersion.outputs.version }}
-  #     tag: ${{ needs.getVersion.outputs.tag }}
-  #     channel: ${{ needs.getVersion.outputs.channel }}
-  #     bypassPackageCheck: true

--- a/.github/workflows/essentialsplugins-updatereadme-caller.yml
+++ b/.github/workflows/essentialsplugins-updatereadme-caller.yml
@@ -1,0 +1,14 @@
+
+name: Generate README
+
+on:
+  push:
+    branches-ignore:
+      - 'robot-docs'
+
+jobs:
+  call-update-readme:
+    uses: PepperDash/workflow-templates/.github/workflows/update-readme.yml@main
+    with:
+      target-branch: ${{ github.ref_name }}
+


### PR DESCRIPTION
This PR standardizes the required GitHub Actions caller workflows for EPI plugins.
- Ensures required callers exist and match templates
- Deletes known legacy workflow files
- Uses the 'workflow-standardization' branch (no direct commits)